### PR TITLE
Change build archive name and remove .env from prod build

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 NODE_ENV=development
-AWS_DEFAULT_REGION=eu-west-2
+AWS_DEFAULT_REGION=eu-west-1
 EMAIL_TEMPLATE_S3_ENDPOINT=http://host.docker.internal:8000
 # Set this to `true` to force the request to use path-style addressing when an endpoint is defined,
 # i.e., `http://s3.amazonaws.com/BUCKET/KEY`

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,9 +1,7 @@
 const path = require('path');
 const AwsSamPlugin = require('aws-sam-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 
 const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false });
-const LAMBDA_NAME = 'ConfirmationFunction'; // must correspond to lambda name in template.yml
 
 module.exports = {
   // Loads the entry object from the AWS::Serverless::Function resources in your
@@ -40,11 +38,6 @@ module.exports = {
 
   // Add the AWS SAM Webpack plugin
   plugins: [
-    awsSamPlugin,
-    new CopyPlugin({
-      patterns: [
-        { from: './.env', to: `.aws-sam/build/${LAMBDA_NAME}/` },
-      ],
-    }),
+    awsSamPlugin
   ],
 };

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,7 +1,17 @@
 const { merge } = require('webpack-merge');
+const CopyPlugin = require('copy-webpack-plugin');
 const common = require('./webpack.common.js');
+
+const LAMBDA_NAME = 'ConfirmationFunction'; // must correspond to lambda name in template.yml
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: './.env', to: `.aws-sam/build/${LAMBDA_NAME}/` },
+      ],
+    }),
+  ],
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -6,7 +6,8 @@ const branchName = require('current-git-branch');
 
 const LAMBDA_NAME = 'ConfirmationFunction';
 const OUTPUT_FOLDER = './dist'
-const BUILD_VERSION = branchName().replace("/","-");
+const REPO_NAME = 'hvt-email';
+const BRANCH_NAME = branchName().replace("/","-");
 
 class BundlePlugin {
   constructor(params) {
@@ -53,17 +54,20 @@ class BundlePlugin {
   }
 };
 
-module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new BundlePlugin({
-      archives: [
-        {
-          inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
-          outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${LAMBDA_NAME}-${BUILD_VERSION}`,
-        }
-      ],
-    }),
-  ],
-});
+module.exports = env => {
+  let commit = env ? env.commit ? env.commit : 'local' : 'local' ;
+  return merge(common, {
+    mode: 'production',
+    plugins: [
+      new BundlePlugin({
+        archives: [
+          {
+            inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
+            outputPath: `${OUTPUT_FOLDER}`,
+            outputName: `${REPO_NAME}-${BRANCH_NAME}-${commit}`,
+          }
+        ],
+      }),
+    ],
+  })
+}


### PR DESCRIPTION
- Optionally pass in commit id when building so the zip file
is named correctly through build config files, not through
Jenkinsfile scripts
- Pipeline can now call build command:
npm run build:prod -- --env.commit=<commit>
- Remove the .env file from prod builds as this file is only required
for dev builds and should not be included
- Correct default region 
- Ticket #BL-11943